### PR TITLE
Split up mouse wheel events

### DIFF
--- a/C#/AutoHotInterception/Manager.cs
+++ b/C#/AutoHotInterception/Manager.cs
@@ -464,7 +464,7 @@ namespace AutoHotInterception
                 // Process Mice
                 for (var i = 11; i < 21; i++)
                 {
-                    var isMontioredMouse = IsMonitoredDevice(i) == 1;
+                    var isMonitoredMouse = IsMonitoredDevice(i) == 1;
                     var hasSubscription = false;
                     var hasContext = _contextCallbacks.ContainsKey(i);
 
@@ -472,7 +472,7 @@ namespace AutoHotInterception
                     {
                         //Debug.WriteLine($"AHK| Mouse {i} seen - flags: {stroke.mouse.flags}, raw state: {stroke.mouse.state}");
                         var block = false;
-                        if (isMontioredMouse)
+                        if (isMonitoredMouse)
                         {
                             if (stroke.mouse.state != 0 && _mouseButtonMappings.ContainsKey(i))
                             {

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AutoHotInterception
 
 AutoHotInterception(AHI) allows you to execute AutoHotkey code in response to events from a *specific* keyboard or mouse, whilst (optionally) blocking the native functionality (ie stopping Windows from seeing that keyboard or mouse event).  
-In other words, you can use a key on a second (or third, or fourth..) keyboard to trigger AHK code, and that key will not be seen by applications. You can use the *same key* on multiple keyboards for individual actions.  
+In other words, you can use a key on a second (or third, or fourth...) keyboard to trigger AHK code, and that key will not be seen by applications. You can use the *same key* on multiple keyboards for individual actions.  
 Keyboard Keys, Mouse Buttons and Mouse movement (Both Relative and Absolute modes) are supported.
 
 AHI uses the Interception driver by Francisco Lopez
@@ -164,9 +164,10 @@ Where `button` is one of:
 2: Middle Mouse
 3: Side Button 1
 4: Side Button 2
-5: Mouse Wheel
+5: Mouse Wheel (Vertical)
+6: Mouse Wheel (Horizontal)
 ```
-For Mouse Wheel events, the `<state>` parameter will be `1` for Wheel Up and `0` for Wheel Down
+For Mouse Wheel events, the `<state>` parameter will be `1` for Wheel Up / Right and `-1` for Wheel Down / Left
 
 Otherwise, usage is identical to `SubscribeKey`  
 
@@ -221,7 +222,7 @@ You can send clicks and other mouse button events with:
 `Interception.SendMouseButtonEvent(<mouseId>, <button>, <state>)`  
 Where `button` is the button index, as used in `SubscribeMouseButton`  
 
-When Sending Mouse Wheel events, set `<state>` to `1` for Wheel Up and `-1` for Wheel Down.
+When Sending Mouse Wheel events, set `<state>` to `1` for Wheel Up / Right and `-1` for Wheel Down / Left.
 
 If you are working in Absolute mode (eg with a graphics tablet or light guns), you can send mouse button events at specific coordinates using:  
 `Interception.SendMouseButtonEventAbsolute(<mouseId>, <button>, <state>, <x>, <y>)`  


### PR DESCRIPTION
I needed a way to detect horizontal mouse wheel input for a project of mine and Interception library supports that but for some reason it wasn't available in your wrapper. I just added a new "button" id to the list that allows for finer control over mouse wheel.