### PR TITLE
Automatically load interception library with correct bitness

### DIFF
--- a/C#/AutoHotInterception/AutoHotInterception.csproj
+++ b/C#/AutoHotInterception/AutoHotInterception.csproj
@@ -48,7 +48,10 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PreBuildEvent>if not exist "$(TargetDir)interception.dll" xcopy "$(SolutionDir)dependencies\interception.dll" "$(TargetDir)"</PreBuildEvent>
+    <PreBuildEvent>if not exist "$(TargetDir)\x86" mkdir "$(TargetDir)\x86"
+if not exist "$(TargetDir)\x64" mkdir "$(TargetDir)\x64"
+if not exist "$(TargetDir)\x86\interception.dll" xcopy "$(SolutionDir)\dependencies\x86\interception.dll" "$(TargetDir)\x86"
+if not exist "$(TargetDir)\x64\interception.dll" xcopy "$(SolutionDir)\dependencies\x64\interception.dll" "$(TargetDir)\x64"</PreBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PostBuildEvent>xcopy /Q /Y "$(TargetPath)" "$(SolutionDir)..\Lib"</PostBuildEvent>

--- a/C#/AutoHotInterception/lib/ManagedWrapper.cs
+++ b/C#/AutoHotInterception/lib/ManagedWrapper.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.IO;
+using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace AutoHotInterception
 {
@@ -230,6 +228,16 @@ namespace AutoHotInterception
             public KeyStroke key;
         }
 
+        static ManagedWrapper()
+        {
+            var folder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var subfolder = Environment.Is64BitProcess ? "\\x64\\" : "\\x86\\";
+
+            LoadLibrary(folder + subfolder + "interception.dll");
+        }
+
+        [DllImport("kernel32.dll")]
+        private static extern IntPtr LoadLibrary(string dllToLoad);
 
         [DllImport("interception.dll", EntryPoint = "interception_create_context", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr CreateContext();

--- a/C#/TestApp/TestApp.csproj
+++ b/C#/TestApp/TestApp.csproj
@@ -56,6 +56,9 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PreBuildEvent>if not exist "$(TargetDir)interception.dll" xcopy "$(SolutionDir)dependencies\interception.dll" "$(TargetDir)"</PreBuildEvent>
+    <PreBuildEvent>if not exist "$(TargetDir)\x86" mkdir "$(TargetDir)\x86"
+if not exist "$(TargetDir)\x64" mkdir "$(TargetDir)\x64"
+if not exist "$(TargetDir)\x86\interception.dll" xcopy "$(SolutionDir)\dependencies\x86\interception.dll" "$(TargetDir)\x86"
+if not exist "$(TargetDir)\x64\interception.dll" xcopy "$(SolutionDir)\dependencies\x64\interception.dll" "$(TargetDir)\x64"</PreBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Lib/AutoHotInterception.ahk
+++ b/Lib/AutoHotInterception.ahk
@@ -4,18 +4,19 @@ class AutoHotInterception {
 	_contextManagers := {}
 	;_contextStates := {}
 	__New(cls := "Manager"){
-		dllName := "Interception.dll"
-		dllFile := A_LineFile "\..\" dllName
+		bitness := A_PtrSize == 8 ? "x64" : "x86"
+		dllName := "interception.dll"
+		dllFile := A_LineFile "\..\" bitness "\" dllName
 		if (!FileExist(dllFile)){
-			MsgBox % "Unable to find lib\" dllName ", exiting...`nYou should take a copy of this file from where you installed Interception, and drop it into AHI's lib folder"
+			MsgBox % "Unable to find lib\" bitness "\" dllName ", exiting...`nYou should extract both x86 and x64 folders from the library folder in interception.zip into AHI's lib folder."
 			ExitApp
 		}
-		
+
 		hModule := DllCall("LoadLibrary", "Str", dllFile, "Ptr")
 		if (hModule == 0){
 			this_bitness := A_PtrSize == 8 ? "64-bit" : "32-bit"
 			other_bitness := A_PtrSize == 4 ? "64-bit" : "32-bit"
-			MsgBox % "Bitness of Interception.dll does not match bitness of AHK.`nAHK is " this_bitness ", but Interception.dll is " other_bitness
+			MsgBox % "Bitness of " dllName " does not match bitness of AHK.`nAHK is " this_bitness ", but " dllName " is " other_bitness "."
 			ExitApp
 		}
 		DllCall("FreeLibrary", "Ptr", hModule)
@@ -27,7 +28,7 @@ class AutoHotInterception {
 			MsgBox % "Unable to find lib\" dllName ", exiting..."
 			ExitApp
 		}
-		
+
 		asm := CLR_LoadLibrary(dllFile)
 		try {
 			this.Instance := asm.CreateInstance("AutoHotInterception." cls)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ![GitHub release](https://img.shields.io/github/release/evilc/autohotinterception.svg)
-[![Github All Releases](https://img.shields.io/github/downloads/evilc/autohotinterception/total.svg)]
+![Github All Releases](https://img.shields.io/github/downloads/evilc/autohotinterception/total.svg)
 [![Discord](https://img.shields.io/discord/330423308103319562.svg)](https://discord.gg/9d3DNN4)
 ![Github commits (since latest release)](https://img.shields.io/github/commits-since/evilc/autohotinterception/latest.svg)
 
 
 # AutoHotInterception
 
-AutoHotInterception(AHI) allows you to execute AutoHotkey code in response to events from a *specific* keyboard or mouse, whilst (optionally) blocking the native functionality (ie stopping Windows from seeing that keyboard or mouse event).  
+AutoHotInterception (AHI) allows you to execute AutoHotkey code in response to events from a *specific* keyboard or mouse, whilst (optionally) blocking the native functionality (ie stopping Windows from seeing that keyboard or mouse event).  
 In other words, you can use a key on a second (or third, or fourth...) keyboard to trigger AHK code, and that key will not be seen by applications. You can use the *same key* on multiple keyboards for individual actions.  
 Keyboard Keys, Mouse Buttons and Mouse movement (Both Relative and Absolute modes) are supported.
 
@@ -50,7 +50,7 @@ You will need to know the VID / PID of at least one of your devices in order to 
 DO NOT use the "Clone or Download" link on the main page.  
 This is the folder where (at least initially) you will be running scripts from.  
 It contains a number of sample `.ahk` scripts and a `lib` folder, which contains all the libraries and files needed for AHI.  
-3. Copy the `interception.dll` from the folder where you ran the interecption install into the `lib` folder that was created in step (2)  
+3. Extract both `x86` and `x64` folders from the `library` folder in `interception.zip` into the `lib` folder that was created in step (2).
 4. Right-click `Unblocker.ps1` in the lib folder and select `Run as Admin`.  
   This is because downloaded DLLs are often blocked and will not work.  
   This can be done manually by right clicking the DLLs, selecting Properties, and checking a "Block" box if it exists.  


### PR DESCRIPTION
Since AHI is already compiled for Any CPU (works on 32 bit and 64 bit machines), we can load the interception library of correct bitness automatically. Therefore I added static loading for the interception library that automatically chooses the correct bitness of the interception library and modified the AutoHotInterception.ahk wrapper accordingly.