### PR TITLE
Add keypress filter to monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 ### Added
+- Add option to filter key presses and only show key releases
 ### Changed
 ### Deprecated
 ### Removed
 ### Fixed
+- GUI layout made more robust
 
 ## [0.4.2] - 2019-06-08
 - Fixed issue #37  

--- a/Monitor.ahk
+++ b/Monitor.ahk
@@ -7,47 +7,56 @@ Script to show data flowing from Interception
 
 OutputDebug DBGVIEWCLEAR
 
-global DeviceList := {}
+DeviceList := {}
 filterMouseMove := 1
 filterKeyPress := 0
 
-;~ global Monitor := AutoHotInterception_Init("InterceptionMonitor")
 MonitorWrapper := new AutoHotInterception("Monitor")
-global Monitor := MonitorWrapper.Instance
+Monitor := MonitorWrapper.Instance
 
+; Device List
 DeviceList := MonitorWrapper.GetDeviceList()
-
-start := 0
 
 colWidth := 350
 Gui, Add, Text, w%colWidth% Center Section, Keyboards
-Loop 2 {
-	isMouse := A_Index - 1
-	Loop 10 {
-		i := start + A_Index
-		dev := DeviceList[i]
-		if (!IsObject(dev)){
-			continue
-		}
-		Gui, Add, Checkbox, % "hwndhCb w" colWidth, % "ID: " dev.id ", VID: 0x" FormatHex(dev.VID) ", PID: 0x" FormatHex(dev.PID) "`nHandle: " StrReplace(dev.Handle, "&", "&&")
-		fn := Func("CheckboxChanged").Bind(dev.id)
-		GuiControl, +g, % hCb, % fn
+Loop 10 {
+	i := A_Index
+	dev := DeviceList[i]
+	if (!IsObject(dev)){
+		continue
 	}
-	if (!IsMouse){
-		Gui, Add, Text, x+5 ym w%colWidth% Center Section, Mice
-		start := 10
-	}
+	Gui, Add, Checkbox, % "hwndhCb w" colWidth, % "ID: " dev.id ", VID: 0x" FormatHex(dev.VID) ", PID: 0x" FormatHex(dev.PID) "`nHandle: " StrReplace(dev.Handle, "&", "&&")
+	fn := Func("CheckboxChanged").Bind(dev.id)
+	GuiControl, +g, % hCb, % fn
+	lowest := UpdateLowest(hCb)
 }
 
-Gui, Add, CheckBox, w%colWidth% y+20 hwndhCbFilterMove Checked, Filter Movement (Warning: Turning off can cause crashes)
+Gui, Add, Text, x+5 ym w%colWidth% Center Section, Mice
+Loop 10 {
+	i := A_Index + 10
+	dev := DeviceList[i]
+	if (!IsObject(dev)){
+		continue
+	}
+	Gui, Add, Checkbox, % "hwndhCb w" colWidth, % "ID: " dev.id ", VID: 0x" FormatHex(dev.VID) ", PID: 0x" FormatHex(dev.PID) "`nHandle: " StrReplace(dev.Handle, "&", "&&")
+	fn := Func("CheckboxChanged").Bind(dev.id)
+	GuiControl, +g, % hCb, % fn
+	lowest := UpdateLowest(hCb)
+}
+
+; Options
+Gui, Add, CheckBox, % "w" colWidth " x10 y" lowest + 20 " hwndhCbFilterPress", Only show key releases
+fn := Func("FilterPress")
+GuiControl, +g, % hCbFilterPress, % fn
+
+Gui, Add, CheckBox, % "x+5 w" colWidth " y" lowest + 20 " hwndhCbFilterMove Checked", Filter Movement (Warning: Turning off can cause crashes)
 fn := Func("FilterMove")
 GuiControl, +g, % hCbFilterMove, % fn
-Gui, Add, CheckBox, w%colWidth% x10 y52 hwndhCbFilterPress, Show Presses instead of ups and downs
-fnn := Func("FilterPress")
-GuiControl, +g, % hCbFilterPress, % fnn
+
 Gui, Add, Button, xm w%colWidth% Center gClearKeyboard, Clear
 Gui, Add, Button, x+5 yp w%colWidth% gClearMouse Center, Clear
 
+; Output
 Gui, Add, ListView, xm w%colWidth% h400 hwndhLvKeyboard, ID|Code|State|Key Name|Info
 LV_ModifyCol(4, 100)
 LV_ModifyCol(5, 150)
@@ -59,7 +68,18 @@ Gui, Show
 Monitor.Subscribe(Func("KeyboardEvent"), Func("MouseEvent"))
 return
 
+UpdateLowest(hwnd){
+	static lowest := 0
+	GuiControlGet, cp, pos, % hwnd
+	low := cpY + cpH
+	if (low > lowest){
+		lowest := low
+	}
+	return lowest
+}
+
 CheckboxChanged(id, hwnd){
+	global Monitor
 	GuiControlGet, state, , % hwnd
 	ret := Monitor.SetDeviceFilterState(id, state)
 	;~ ToolTip % "Changed " id " to " state ". Return value: " ret

--- a/Monitor.ahk
+++ b/Monitor.ahk
@@ -3,7 +3,7 @@ Script to show data flowing from Interception
 */
 #SingleInstance force
 #Persistent
-#include <AutoHotInterception>
+#include Lib\AutoHotInterception.ahk
 
 OutputDebug DBGVIEWCLEAR
 

--- a/Monitor.ahk
+++ b/Monitor.ahk
@@ -3,12 +3,13 @@ Script to show data flowing from Interception
 */
 #SingleInstance force
 #Persistent
-#include Lib\AutoHotInterception.ahk
+#include <AutoHotInterception>
 
 OutputDebug DBGVIEWCLEAR
 
 global DeviceList := {}
 filterMouseMove := 1
+filterKeyPress := 0
 
 ;~ global Monitor := AutoHotInterception_Init("InterceptionMonitor")
 MonitorWrapper := new AutoHotInterception("Monitor")
@@ -41,6 +42,9 @@ Loop 2 {
 Gui, Add, CheckBox, w%colWidth% y+20 hwndhCbFilterMove Checked, Filter Movement (Warning: Turning off can cause crashes)
 fn := Func("FilterMove")
 GuiControl, +g, % hCbFilterMove, % fn
+Gui, Add, CheckBox, w%colWidth% x10 y52 hwndhCbFilterPress, Show Presses instead of ups and downs
+fnn := Func("FilterPress")
+GuiControl, +g, % hCbFilterPress, % fnn
 Gui, Add, Button, xm w%colWidth% Center gClearKeyboard, Clear
 Gui, Add, Button, x+5 yp w%colWidth% gClearMouse Center, Clear
 
@@ -67,6 +71,12 @@ FilterMove(hwnd){
 	filterMouseMove := state
 }
 
+FilterPress(hwnd){
+	global filterKeyPress
+	GuiControlGet, state, , % hwnd
+	filterKeyPress := state
+}
+
 ClearKeyboard:
 	Gui, ListView, % hLvKeyboard
 	LV_Delete()
@@ -82,7 +92,9 @@ FormatHex(num){
 }
 
 KeyboardEvent(id, code, state, info){
-	global hLvKeyboard
+	global hLvKeyboard, filterKeyPress
+    if (filterKeyPress && state)
+        return
 	Gui, ListView, % hLvKeyboard
 	scanCode := Format("{:x}", code)
 	keyName := GetKeyName("SC" scanCode)


### PR DESCRIPTION
Add checkbox for filtering only keyup event's so we have no "double" events (disabled by default)
currently the horizontal alignment is fixed, i have no idea how to make it dynamic