### PR TITLE
Fix Context Mode failing sometimes

### DIFF
--- a/C#/AutoHotInterception/Manager.cs
+++ b/C#/AutoHotInterception/Manager.cs
@@ -665,12 +665,15 @@ namespace AutoHotInterception
                     // If the key was blocked by Subscription Mode, then move on to next key...
                     if (block) continue;
 
-                    // If this key had no subscriptions, but Context Mode is set for this keyboard...
-                    // ... then set the Context before sending the key
+
                     if (!hasSubscription && hasContext) _contextCallbacks[i](1);
 
                     // Pass the key through to the OS.
                     ManagedWrapper.Send(_deviceContext, i, ref stroke, 1);
+
+                    // Wait for polling. This is a fix for context mode failing sometimes.
+                    // There is a race condition for the Context Mode state, this fixes that.
+                    Thread.Sleep(1);
 
                     // If we are processing Context Mode, then Unset the context variable after sending the key
                     if (!hasSubscription && hasContext) _contextCallbacks[i](0);
@@ -889,6 +892,7 @@ namespace AutoHotInterception
                         // Context Mode - forward stroke with context wrapping
                         _contextCallbacks[i](1);
                         ManagedWrapper.Send(_deviceContext, i, ref stroke, 1);
+                        Thread.Sleep(1);
                         _contextCallbacks[i](0);
                     }
                     else

--- a/C#/AutoHotInterception/Manager.cs
+++ b/C#/AutoHotInterception/Manager.cs
@@ -665,18 +665,22 @@ namespace AutoHotInterception
                     // If the key was blocked by Subscription Mode, then move on to next key...
                     if (block) continue;
 
-
+                    // If this key had no subscriptions, but Context Mode is set for this keyboard...
+                    // ... then set the Context before sending the key
                     if (!hasSubscription && hasContext) _contextCallbacks[i](1);
 
                     // Pass the key through to the OS.
                     ManagedWrapper.Send(_deviceContext, i, ref stroke, 1);
 
-                    // Wait for polling. This is a fix for context mode failing sometimes.
-                    // There is a race condition for the Context Mode state, this fixes that.
-                    Thread.Sleep(1);
+                    if (!hasSubscription && hasContext)
+                    {
+                        // Wait for polling. This is a fix for context mode failing sometimes.
+                        // There is a race condition for the Context Mode state, this fixes that.
+                        Thread.Sleep(1);
 
-                    // If we are processing Context Mode, then Unset the context variable after sending the key
-                    if (!hasSubscription && hasContext) _contextCallbacks[i](0);
+                        // If we are processing Context Mode, then Unset the context variable after sending the key
+                        _contextCallbacks[i](0);
+                    }
                 }
             }
 

--- a/C#/AutoHotInterception/Manager.cs
+++ b/C#/AutoHotInterception/Manager.cs
@@ -672,15 +672,8 @@ namespace AutoHotInterception
                     // Pass the key through to the OS.
                     ManagedWrapper.Send(_deviceContext, i, ref stroke, 1);
 
-                    if (!hasSubscription && hasContext)
-                    {
-                        // Wait for polling. This is a fix for context mode failing sometimes.
-                        // There is a race condition for the Context Mode state, this fixes that.
-                        Thread.Sleep(1);
-
-                        // If we are processing Context Mode, then Unset the context variable after sending the key
-                        _contextCallbacks[i](0);
-                    }
+                    // If we are processing Context Mode, then Unset the context variable after sending the key
+                    if (!hasSubscription && hasContext) _contextCallbacks[i](0);
                 }
             }
 
@@ -896,7 +889,6 @@ namespace AutoHotInterception
                         // Context Mode - forward stroke with context wrapping
                         _contextCallbacks[i](1);
                         ManagedWrapper.Send(_deviceContext, i, ref stroke, 1);
-                        Thread.Sleep(1);
                         _contextCallbacks[i](0);
                     }
                     else

--- a/C#/AutoHotInterception/Manager.cs
+++ b/C#/AutoHotInterception/Manager.cs
@@ -672,8 +672,15 @@ namespace AutoHotInterception
                     // Pass the key through to the OS.
                     ManagedWrapper.Send(_deviceContext, i, ref stroke, 1);
 
-                    // If we are processing Context Mode, then Unset the context variable after sending the key
-                    if (!hasSubscription && hasContext) _contextCallbacks[i](0);
+                    if (!hasSubscription && hasContext)
+                    {
+                        // Wait for polling. This is a fix for context mode failing sometimes.
+                        // There is a race condition for the Context Mode state, this fixes that.
+                        Thread.Sleep(1);
+
+                        // If we are processing Context Mode, then Unset the context variable after sending the key
+                        _contextCallbacks[i](0);
+                    }
                 }
             }
 
@@ -889,6 +896,7 @@ namespace AutoHotInterception
                         // Context Mode - forward stroke with context wrapping
                         _contextCallbacks[i](1);
                         ManagedWrapper.Send(_deviceContext, i, ref stroke, 1);
+                        Thread.Sleep(1);
                         _contextCallbacks[i](0);
                     }
                     else

--- a/Lib/AutoHotInterception.ahk
+++ b/Lib/AutoHotInterception.ahk
@@ -243,7 +243,6 @@ class AutoHotInterception {
 		}
 		
 		OnContextCallback(state) {
-			Sleep 0
 			this.IsActive := state
 		}
 	}


### PR DESCRIPTION
I noticed that in about 1/10 cases while pressing keys on my numpad keyboard, the key would fail to remap using the following AHK code:

![image](https://user-images.githubusercontent.com/7478134/98511756-39016000-2233-11eb-8dc2-e9ac644c80be.png)

During polling, the context state is set several times while a filtered device's keys get pressed. Looks like a race condition exists where AHK recognizes when a key gets pressed (when it checks cm.IsActive) and when the callback state gets set to 0, so to fix that I added a sleep before the context is set back to 0.

Haven't had a hitch yet with that change but I am trying some other ideas.