### PR TITLE
Pause/Numlock support

### DIFF
--- a/C#/AutoHotInterception/Helpers/HelperFunctions.cs
+++ b/C#/AutoHotInterception/Helpers/HelperFunctions.cs
@@ -170,16 +170,21 @@ namespace AutoHotInterception.Helpers
             return buttonStates.ToArray();
         }
 
-        public static KeyboardState KeyboardStrokeToKeyboardState(ManagedWrapper.Stroke stroke)
+        public static KeyboardState KeyboardStrokeToKeyboardState(ManagedWrapper.Stroke stroke, bool lct)
         {
             var code = stroke.key.code;
             var state = stroke.key.state;
             var retVal = new KeyboardState();
+            retVal.ChangeLctrl = 0;
             if (code == 54 /* Right Shift */ || code == 69 /* NumLock */) code += 256;
 
             // If state is shifted up by 2 (1 or 2 instead of 0 or 1), then this is an "Extended" key code
             if (state > 1)
             {
+                if (code == 29 && state == 4)
+                {
+                    retVal.ChangeLctrl = 1;
+                }
                 if (code == 42 || state > 3)
                 {
                     // code == 42
@@ -209,6 +214,15 @@ namespace AutoHotInterception.Helpers
                 }
             }
 
+            if (code == 325 && lct == true)
+            {
+                if (state == 1)
+                {
+                    retVal.ChangeLctrl = 2;
+                }
+                code = 69;
+            }
+
             retVal.Code = code;
             retVal.State = (ushort) (1 - state);
             return retVal;
@@ -235,6 +249,7 @@ namespace AutoHotInterception.Helpers
             public ushort Code { get; set; }
             public ushort State { get; set; }
             public bool Ignore { get; set; }
+            public int ChangeLctrl { get; set; }
         }
     }
 }

--- a/C#/AutoHotInterception/Manager.cs
+++ b/C#/AutoHotInterception/Manager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Threading;
@@ -44,6 +44,7 @@ namespace AutoHotInterception
 
         private readonly MultimediaTimer _timer;
         private readonly int _pollRate = 1;
+        private volatile bool _lctr = false;
         private volatile bool _pollThreadRunning;
         private bool _absoluteMode00Reported;
 
@@ -66,6 +67,11 @@ namespace AutoHotInterception
         public string OkCheck()
         {
             return "OK";
+        }
+
+        public void SetLctrl(bool l)
+        {
+            _lctr = l;
         }
 
         public void SetState(bool state)
@@ -597,10 +603,19 @@ namespace AutoHotInterception
                     if (isMonitoredKeyboard)
                     {
                         var isKeyMapping = false; // True if this is a mapping to a single key, else it would be a mapping to a whole device
-                        var processedState = HelperFunctions.KeyboardStrokeToKeyboardState(stroke);
+                        var processedState = HelperFunctions.KeyboardStrokeToKeyboardState(stroke, _lctr);
                         var code = processedState.Code;
                         var state = processedState.State;
                         MappingOptions mapping = null;
+
+                        if (processedState.ChangeLctrl == 1)
+                        {
+                            _lctr = true;
+                        }
+                        else if (processedState.ChangeLctrl == 2)
+                        {
+                            _lctr = false;
+                        }
 
                         if (_keyboardMappings.ContainsKey(i))
                         {

--- a/C#/AutoHotInterception/Manager.cs
+++ b/C#/AutoHotInterception/Manager.cs
@@ -398,7 +398,12 @@ namespace AutoHotInterception
                 default:
                     st = state; break;
             }
-
+            if (code > 255)
+            {
+                code -= 256;
+                if (code != 54) // RShift has > 256 code, but state is 0/1
+                    st += 2;
+            }
             stroke.key.code = code;
             stroke.key.state = (ushort) st;
             ManagedWrapper.Send(_deviceContext, id, ref stroke, 1);

--- a/C#/AutoHotInterception/Manager.cs
+++ b/C#/AutoHotInterception/Manager.cs
@@ -390,6 +390,7 @@ namespace AutoHotInterception
         {
             HelperFunctions.IsValidDeviceId(false, id);
             int st;
+            var stroke = new ManagedWrapper.Stroke();
             switch (state) {
                 case 0:
                     st = 1; break;

--- a/C#/AutoHotInterception/Manager.cs
+++ b/C#/AutoHotInterception/Manager.cs
@@ -389,13 +389,14 @@ namespace AutoHotInterception
         public void SendKeyEvent(int id, ushort code, int state)
         {
             HelperFunctions.IsValidDeviceId(false, id);
-            var st = 1 - state;
-            var stroke = new ManagedWrapper.Stroke();
-            if (code > 255)
-            {
-                code -= 256;
-                if (code != 54) // RShift has > 256 code, but state is 0/1
-                    st += 2;
+            int st;
+            switch (state) {
+                case 0:
+                    st = 1; break;
+                case 1:
+                    st = 0; break;
+                default:
+                    st = state; break;
             }
 
             stroke.key.code = code;


### PR DESCRIPTION
A pause key can be simulated by first sending LeftControl with a state of 4/5.
```
AHI.SendKeyEvent(keyboardID, GetKeySC("LControl"), 5)
AHI.SendKeyEvent(keyboardID, GetKeySC("Pause"), 1)
AHI.SendKeyEvent(keyboardID, GetKeySC("LControl"), 4)
AHI.SendKeyEvent(keyboardID, GetKeySC("Pause"), 0)
```