### PR TITLE
SubscribeKey Extended for v1

### DIFF
--- a/AHK v1/Lib/AutoHotInterception.ahk
+++ b/AHK v1/Lib/AutoHotInterception.ahk
@@ -166,7 +166,13 @@ class AutoHotInterception {
 
 	; ---------------------- Subscription Mode ----------------------
 	SubscribeKey(id, code, block, callback, concurrent := false) {
-		this.Instance.SubscribeKey(id, code, block, callback, concurrent)
+		switch callback.MaxParams
+		{
+			case 1:
+				this.Instance.SubscribeKey(id, code, block, callback, concurrent)
+			case 2:
+				this.Instance.SubscribeKeyEx(id, code, block, callback, concurrent)
+		}
 	}
 
 	UnsubscribeKey(id, code){

--- a/C#/AutoHotInterception/DeviceHandlers/IDeviceHandler.cs
+++ b/C#/AutoHotInterception/DeviceHandlers/IDeviceHandler.cs
@@ -20,6 +20,13 @@ namespace AutoHotInterception.DeviceHandlers
         void SubscribeSingleButton(ushort code, MappingOptions mappingOptions);
 
         /// <summary>
+        /// Subscribes to a single key or button of this device
+        /// </summary>
+        /// <param name="code">The ScanCode (keyboard) or Button Code (mouse) for the key or button</param>
+        /// <param name="mappingOptions">Options for the subscription (block, callback to fire etc)</param>
+        void SubscribeSingleButtonEx(ushort code, MappingOptions mappingOptions);
+
+        /// <summary>
         /// Unsubscribes from a single key or button of this device
         /// </summary>
         /// <param name="code">The ScanCode (keyboard) or Button Code (mouse) for the key or button</param>

--- a/C#/AutoHotInterception/Manager.cs
+++ b/C#/AutoHotInterception/Manager.cs
@@ -87,11 +87,49 @@ namespace AutoHotInterception
         }
 
         /// <summary>
+        ///     Subscribes to a Keyboard key
+        /// </summary>
+        /// <param name="id">The ID of the Keyboard</param>
+        /// <param name="code">The ScanCode of the key</param>
+        /// <param name="block">Whether or not to block the key</param>
+        /// <param name="callback">The callback to fire when the key changes state</param>
+        /// <param name="concurrent">Whether or not to execute callbacks concurrently</param>
+        /// <returns></returns>
+        public void SubscribeKeyEx(int id, ushort code, bool block, dynamic callback, bool concurrent = false)
+        {
+            HelperFunctions.IsValidDeviceId(false, id);
+            SetFilterState(false);
+
+            var handler = DeviceHandlers[id];
+            handler.SubscribeSingleButtonEx(code, new MappingOptions { Block = block, Concurrent = concurrent, Callback = callback });
+
+            SetFilterState(true);
+            SetThreadState(true);
+        }
+
+        /// <summary>
         /// Unsubscribe from a keyboard key
         /// </summary>
         /// <param name="id">The id of the keyboard</param>
         /// <param name="code">The Scancode of the key</param>
         public void UnsubscribeKey(int id, ushort code)
+        {
+            HelperFunctions.IsValidDeviceId(false, id);
+            SetFilterState(false);
+
+            var handler = DeviceHandlers[id];
+            handler.UnsubscribeSingleButton(code);
+
+            SetFilterState(true);
+            SetThreadState(true);
+        }
+
+        /// <summary>
+        /// Unsubscribe from a keyboard key
+        /// </summary>
+        /// <param name="id">The id of the keyboard</param>
+        /// <param name="code">The Scancode of the key</param>
+        public void UnsubscribeKeyEx(int id, ushort code)
         {
             HelperFunctions.IsValidDeviceId(false, id);
             SetFilterState(false);

--- a/C#/TestApp/KeyboardKeyTester.cs
+++ b/C#/TestApp/KeyboardKeyTester.cs
@@ -16,11 +16,16 @@ namespace TestApp
             if (devId == 0) return;
 
             im.SubscribeKey(devId, 0x2, block, new Action<int>(OnKeyEvent));
+            im.SubscribeKeyEx(devId, 0x3, block, new Action<int,ushort>(OnKeyEventEx));
         }
 
         public void OnKeyEvent(int value)
         {
             Console.WriteLine($"State: {value}");
+        }
+        public void OnKeyEventEx(int value, ushort code)
+        {
+            Console.WriteLine($"State: {value}   Code: {code}");
         }
 
     }


### PR DESCRIPTION
Allows you to optionally add a second parameter to any SubscribeKey callback function for reference purposes. For example, you can subscribe/unsubscribe to individual keys dynamically. Sometimes you may not know which exact keys you want to subscribe to until later in your code. Also can keep some scripts shorter when you can make use of one callback function that only needs minor adjustment based on the key that triggers it.