### PR TITLE
set overwrite flag when creating library files

### DIFF
--- a/AHK v2/Lib/AutoHotInterception.ahk
+++ b/AHK v2/Lib/AutoHotInterception.ahk
@@ -9,13 +9,13 @@ class AutoHotInterception {
 		if (A_IsCompiled) {
 			dllFile := A_LineFile "\..\Lib\" bitness "\" dllName
 			DirCreate("Lib")
-			FileInstall("Lib\AutoHotInterception.dll", "Lib\AutoHotInterception.dll", 1)
+			FileInstall("Lib\AutoHotInterception.dll", "Lib\AutoHotInterception.dll")
 			if (bitness == "x86") {
 				DirCreate("Lib\x86")
-				FileInstall("Lib\x86\interception.dll", "Lib\x86\interception.dll", 1)
+				FileInstall("Lib\x86\interception.dll", "Lib\x86\interception.dll")
 			} else {
 				DirCreate("Lib\x64")
-				FileInstall("Lib\x64\interception.dll", "Lib\x64\interception.dll", 1)
+				FileInstall("Lib\x64\interception.dll", "Lib\x64\interception.dll")
 			}
 		} else {
 			dllFile := A_LineFile "\..\" bitness "\" dllName


### PR DESCRIPTION
This was my solution to https://github.com/evilC/AutoHotInterception/issues/102. Setting the flag to 1 causes it to overwrite any existing files instead of failing. (https://www.autohotkey.com/docs/v2/lib/FileInstall.htm)

Perhaps a better solution would be to check if the file already exists, and refrain from writing any file at all, but I am very new to AHK, so did not try.

[EDIT: sorry, the diff looks backwards, looking to see what I did wrong with this pr...]